### PR TITLE
Caculating the default ttl in milliseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
 # [develop](https://github.com/mojolingo/mojo-auth.js)
+### Fixed
+- Caculating the ttl in milliseconds
 
 # [v0.1.0](https://github.com/mojolingo/mojo-auth.js/compare/c8686b66a4c3950e1fa0c7601c52ef6e19d9bf82...v0.1.0) - [2014-10-12](https://www.npmjs.org/package/mojo-auth.js/0.1.0)

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,7 +36,7 @@ exports.createSecret = function () {
  */
 exports.createCredentials = function (args) {
   var secret = args.secret || required('secret')
-    , ttl = args.ttl || DAY_IN_SECONDS
+    , ttl = (args.ttl || DAY_IN_SECONDS) * 1000
     , expiryTimestamp = new Date().getTime() + ttl
     , username = [expiryTimestamp, args.id].join(':')
     ;


### PR DESCRIPTION
This commit fixes the ttl calculation.

Date#getTime() returns the number of milliseconds since 1 January 1970 00:00:00 UTC, therefore this fix the ttl duration window which was being mistakenly calculated in milliseconds. The user passes (and also the default ttl) was in seconds.
