### PR TITLE
Removing milliseconds before generating the timestamp and testing credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # [develop](https://github.com/mojolingo/mojo-auth.js)
 ### Fixed
+- Removing milliseconds before generating the timestamp and testing credentials
+
+### Fixed
 - Caculating the ttl in milliseconds
 
 # [v0.1.0](https://github.com/mojolingo/mojo-auth.js/compare/c8686b66a4c3950e1fa0c7601c52ef6e19d9bf82...v0.1.0) - [2014-10-12](https://www.npmjs.org/package/mojo-auth.js/0.1.0)

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,7 +37,7 @@ exports.createSecret = function () {
 exports.createCredentials = function (args) {
   var secret = args.secret || required('secret')
     , ttl = (args.ttl || DAY_IN_SECONDS) * 1000
-    , expiryTimestamp = new Date().getTime() + ttl
+    , expiryTimestamp = Math.floor((new Date().getTime() + ttl) / 1000)
     , username = [expiryTimestamp, args.id].join(':')
     ;
 
@@ -58,7 +58,7 @@ exports.testCredentials = function (credentials, secret) {
     , id = username[1]
     ;
 
-  if (parseInt(expiryTimestamp) < new Date().getTime()) {
+  if (parseInt(expiryTimestamp) < Math.floor(new Date().getTime() / 1000)) {
     return false;
   }
   if (sign(credentials.username, secret) != credentials.password) {

--- a/test/unit.js
+++ b/test/unit.js
@@ -84,8 +84,10 @@ describe('creating and testing credentials', function () {
       });
 
       context('after the window', function () {
+        var oneSecond = 1 * 1000;
+
         beforeEach(function () {
-          Timecop.freeze(currentDate.getTime() + defaultTTL + 1);
+          Timecop.freeze(currentDate.getTime() + defaultTTL + oneSecond);
         });
 
         it('tests false', function () {
@@ -121,8 +123,10 @@ describe('creating and testing credentials', function () {
       });
 
       context('after the window', function () {
+        var oneSecond = 1 * 1000;
+
         beforeEach(function () {
-          Timecop.freeze(futureDate.getTime() + 1);
+          Timecop.freeze(futureDate.getTime() + oneSecond);
         });
 
         it('tests false', function () {
@@ -195,8 +199,10 @@ describe('creating and testing credentials', function () {
       });
 
       context('after the window', function () {
+        var oneSecond = 1 * 1000;
+
         beforeEach(function () {
-          Timecop.freeze(currentDate.getTime() + defaultTTL + 1);
+          Timecop.freeze(currentDate.getTime() + defaultTTL + oneSecond);
         });
 
         it('tests false', function () {
@@ -232,8 +238,10 @@ describe('creating and testing credentials', function () {
       });
 
       context('after the window', function () {
+        var oneSecond = 1 * 1000;
+
         beforeEach(function () {
-          Timecop.freeze(futureDate.getTime() + 1);
+          Timecop.freeze(futureDate.getTime() + oneSecond);
         });
 
         it('tests false', function () {


### PR DESCRIPTION
All other mojo-auth libraries output the timestamp in a Linux epoch in SECONDS. Javascript defaults to MILLISECONDS.

This commit ensures interoperability between different mojo auth libs by removing milliseconds before creating the timestamp and when testing credentials.
